### PR TITLE
Enable auto-completion for the "ibazel" command

### DIFF
--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -56,8 +56,9 @@
 # Some commands might interfer with the important one, so don't complete them
 : ${BAZEL_IGNORED_COMMAND_REGEX:="__none__"}
 
-# Bazel command
+# bazel & ibazel commands
 : ${BAZEL:=bazel}
+: ${IBAZEL:=ibazel}
 
 # Pattern to match for looking for a target
 #  BAZEL_BUILD_MATCH_PATTERN__* give the pattern for label-*
@@ -466,3 +467,4 @@ _bazel__complete_target_stdout() {
 
 # default completion for bazel
 complete -F _bazel__complete -o nospace "${BAZEL}"
+complete -F _bazel__complete -o nospace "${IBAZEL}"


### PR DESCRIPTION
ibazel implements a the same command line interface as bazel, so we can just use the same completion function.

See https://github.com/bazelbuild/bazel-watcher.